### PR TITLE
SCS-562

### DIFF
--- a/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
+++ b/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
@@ -158,6 +158,15 @@ internal extension LinkWebViewViewController {
 extension LinkWebViewViewController: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void) {
+        if let url = navigationAction.request.url {
+            if url.absoluteString.starts(with: "https://link.trustwallet.com") == true {
+                decisionHandler(.cancel)
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
+                return
+            }
+        }
         decisionHandler(.allow)
     }
     

--- a/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
+++ b/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
@@ -155,11 +155,16 @@ internal extension LinkWebViewViewController {
     }
 }
 
+let allowedUrls = [
+    "https://link.trustwallet.com",
+    "https://appopener.meshconnect.com"
+]
+
 extension LinkWebViewViewController: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void) {
         if let url = navigationAction.request.url {
-            if url.absoluteString.starts(with: "https://link.trustwallet.com") == true {
+            if allowedUrls.contains(where: { url.absoluteString.starts(with: $0) }) {
                 decisionHandler(.cancel)
                 if UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
SCS-562: added https://link.trustwallet.com universal link as an exception to load in system browser, instead on webview.