### PR TITLE
XPR-1306 fix allowed external links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-﻿.swiftpm
+.swiftpm
 
 ## User settings
 xcuserdata/
 *.xcworkspace/xcshareddata/swiftpm/
+
+# misc
+.DS_Store

--- a/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
+++ b/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 @preconcurrency import WebKit
 import SafariServices
 
-let meshSDKVersion = "3.1.6"
+let meshSDKVersion = "3.1.7"
 
 let DARK_THEME_COLOR_TOP : UInt = 0x1E1E24
 let LIGHT_THEME_COLOR_TOP : UInt = 0xF3F4F5
@@ -19,6 +19,10 @@ let LIGHT_THEME_COLOR_BOTTOM : UInt = 0xFBFBFB
 let allowedUrls = [
     "https://link.trustwallet.com",
     "https://appopener.meshconnect.com",
+    "https://integration-api.meshconnect.com",
+    "https://sandbox-integration-api.meshconnect.com",
+    "https://dev-integration-api.meshconnect.com",
+    "https://dev-sandbox-integration-api.meshconnect.com",
     "https://www.coinbase.com",
     "https://api.cb-device-intelligence.com"
 ]


### PR DESCRIPTION
This pull request updates the SDK version and expands the list of allowed URLs in the `LinkWebViewViewController.swift` file. The most important changes are:

SDK Version Update:
* Bumped the `meshSDKVersion` constant from "3.1.6" to "3.1.7" to reflect the latest release.

Security and Integration:
* Added four new Mesh Connect API domains to the `allowedUrls` array: `integration-api.meshconnect.com`, `sandbox-integration-api.meshconnect.com`, `dev-integration-api.meshconnect.com`, and `dev-sandbox-integration-api.meshconnect.com`, enabling the web view to interact with these environments.