### PR TITLE
PRG-2378: drop appopener from allowedUrls

### DIFF
--- a/.github/workflows/iOS_SDK.yaml
+++ b/.github/workflows/iOS_SDK.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16'
+          xcode-version: 'latest-stable'
         
 #      - name: Install dependencies
 #        run: |

--- a/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
+++ b/LinkSDK/LinkWebViewController/LinkWebViewViewController.swift
@@ -18,7 +18,6 @@ let LIGHT_THEME_COLOR_BOTTOM : UInt = 0xFBFBFB
 
 let allowedUrls = [
     "https://link.trustwallet.com",
-    "https://appopener.meshconnect.com",
     "https://integration-api.meshconnect.com",
     "https://sandbox-integration-api.meshconnect.com",
     "https://dev-integration-api.meshconnect.com",


### PR DESCRIPTION
Implements PR 2c of 8 for [PRG-2378](https://meshconnectapi.atlassian.net/browse/PRG-2378).

The `appopener.meshconnect.com` host is being retired. The host appeared in `LinkWebViewViewController.allowedUrls` as an allow-list entry. Since the backend no longer constructs URLs to that host (PR 1 of 8 in `FrontBackEnd`), this entry is dead weight.

## Changes
Removes `"https://appopener.meshconnect.com"` from `allowedUrls` in `LinkSDK/LinkWebViewController/LinkWebViewViewController.swift`.

## Compatibility
Allow-list shrink, not a contract change. Old shipped SDKs stay safe.

## Reviewer checklist
- [ ] Build green
- [ ] Bump SDK version (minor) + CHANGELOG
- [ ] Coordinate release with PRG-2378 rollout

PR 2c of 8.

[PRG-2378]: https://meshconnectapi.atlassian.net/browse/PRG-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ