### PR TITLE
OR-565: Update Link token API reference URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/FrontFin/mesh-ios-sdk
 
 ## Get Link token
 
-Link token should be obtained from the POST `/api/v1/linktoken` endpoint. API reference for this request is available [here](https://docs.meshconnect.com/reference/post_api-v1-linktoken). The request must be performed from the server side because it requires the client's secret. You will get the response in the following format:
+Link token should be obtained from the POST `/api/v1/linktoken` endpoint. API reference for this request is available [here](https://docs.meshconnect.com/api-reference/managed-account-authentication/get-link-token-with-parameters). The request must be performed from the server side because it requires the client's secret. You will get the response in the following format:
 ```json
 {
     "content": {


### PR DESCRIPTION
## Summary
Updates the Link token API reference link in the README from the deprecated docs URL to the current one.

- Old: `https://docs.meshconnect.com/reference/post_api-v1-linktoken`
- New: `https://docs.meshconnect.com/api-reference/managed-account-authentication/get-link-token-with-parameters`

## Jira
[OR-565](https://meshconnectapi.atlassian.net/browse/OR-565) (epic: OR-81 — Engineering Excellence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OR-565]: https://meshconnectapi.atlassian.net/browse/OR-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ